### PR TITLE
JIT linear timing to replace relative timing + fix collision

### DIFF
--- a/chirpstack-concentratord-2g4/src/handler/jit.rs
+++ b/chirpstack-concentratord-2g4/src/handler/jit.rs
@@ -56,12 +56,14 @@ pub fn jit_loop(
             }
         }
     }
+
+    debug!("JIT loop ended");
 }
 
 fn get_tx_packet(
     queue: &Arc<Mutex<jitqueue::Queue<wrapper::TxPacket>>>,
 ) -> Option<wrapper::TxPacket> {
-    let concentrator_count = hal::get_instcnt().expect("get concentrator count error");
     let mut queue = queue.lock().unwrap();
+    let concentrator_count = hal::get_instcnt().expect("get concentrator count error");
     return queue.pop(concentrator_count);
 }

--- a/chirpstack-concentratord-sx1301/src/handler/jit.rs
+++ b/chirpstack-concentratord-sx1301/src/handler/jit.rs
@@ -65,8 +65,7 @@ pub fn jit_loop(
 fn get_tx_packet(
     queue: &Arc<Mutex<jitqueue::Queue<wrapper::TxPacket>>>,
 ) -> Option<wrapper::TxPacket> {
-    let concentrator_count = timersync::get_concentrator_count();
     let mut queue = queue.lock().unwrap();
-
+    let concentrator_count = timersync::get_concentrator_count();
     return queue.pop(concentrator_count);
 }

--- a/chirpstack-concentratord-sx1302/src/handler/jit.rs
+++ b/chirpstack-concentratord-sx1302/src/handler/jit.rs
@@ -64,8 +64,7 @@ pub fn jit_loop(
 fn get_tx_packet(
     queue: &Arc<Mutex<jitqueue::Queue<wrapper::TxPacket>>>,
 ) -> Option<wrapper::TxPacket> {
-    let concentrator_count = hal::get_instcnt().expect("get concentrator count error");
     let mut queue = queue.lock().unwrap();
-
+    let concentrator_count = hal::get_instcnt().expect("get concentrator count error");
     return queue.pop(concentrator_count);
 }


### PR DESCRIPTION
This new approach (which is not really a feature) allows to more easily manipulate various timing in the JIT queue.
This is the base work for future improvements and features like regulation (especially the duty cycle limitation calculation).

N.B: Duration manipulation is far more easy than rolling us counter and possible errors are more easily catch since wrapping is not allowed. Also rolling counter management is limited to only 3 functions.