### PR TITLE
Add Fine Timestamp property for consertrator-sx1302 backend 

### DIFF
--- a/chirpstack-concentratord-sx1302/src/cmd/root.rs
+++ b/chirpstack-concentratord-sx1302/src/cmd/root.rs
@@ -160,9 +160,10 @@ pub fn run(
         // gps validate thread
         threads.push(thread::spawn({
             let stop_receive = signal_pool.new_receiver();
+            let time_fallback = config.gateway.time_fallback_enabled;
 
             move || {
-                handler::gps::gps_validate_loop(stop_receive);
+                handler::gps::gps_validate_loop(stop_receive,time_fallback);
             }
         }));
 

--- a/chirpstack-concentratord-sx1302/src/handler/uplink.rs
+++ b/chirpstack-concentratord-sx1302/src/handler/uplink.rs
@@ -42,14 +42,20 @@ pub fn handle_loop(
 
                     let rx_info = proto.rx_info.as_ref().unwrap();
 
+                    let fts = match frame.ftime_received {
+                        true => format!("{:0>9} ns", frame.ftime),
+                        false => "n/a".to_string()
+                    };
+
                     info!(
-                        "Frame received, uplink_id: {}, count_us: {}, freq: {}, bw: {}, mod: {:?}, dr: {:?}",
+                        "Frame received, uplink_id: {}, count_us: {}, freq: {}, bw: {}, mod: {:?}, dr: {:?}, fts: {}",
                         rx_info.uplink_id,
                         frame.count_us,
                         frame.freq_hz,
                         frame.bandwidth,
                         frame.modulation,
                         frame.datarate,
+                        fts,
                     );
 
                     if frame.status == hal::CRC::CRCOk {

--- a/chirpstack-concentratord-sx1302/src/wrapper/mod.rs
+++ b/chirpstack-concentratord-sx1302/src/wrapper/mod.rs
@@ -60,6 +60,20 @@ pub fn uplink_to_proto(
     let mut rng = rand::thread_rng();
     let uplink_id: u32 = rng.gen();
 
+    let gps_cnt2epoch = match gps::cnt2epoch(packet.count_us) {
+        Ok(v) => Some(prost_types::Duration {
+            seconds: v.as_secs() as i64,
+            nanos: v.subsec_nanos() as i32,
+        }),
+        Err(err) => {
+            debug!(
+                "Could not get GPS epoch, uplink_id: {}, error: {}",
+                uplink_id, err
+            );
+            None
+        }
+    };    
+
     Ok(gw::UplinkFrame {
         phy_payload: packet.payload[..packet.size as usize].to_vec(),
         tx_info: Some(gw::UplinkTxInfo {
@@ -133,19 +147,22 @@ pub fn uplink_to_proto(
                     }
                 }
             },
-            time_since_gps_epoch: match gps::cnt2epoch(packet.count_us) {
-                Ok(v) => Some(prost_types::Duration {
-                    seconds: v.as_secs() as i64,
-                    nanos: v.subsec_nanos() as i32,
-                }),
-                Err(err) => {
-                    debug!(
-                        "Could not get GPS epoch, uplink_id: {}, error: {}",
-                        uplink_id, err
-                    );
-                    None
-                }
+            fine_time_since_gps_epoch: match packet.ftime_received {
+                true => {
+                    match &gps_cnt2epoch {
+                        Some(v) => Some( prost_types::Duration {
+                                seconds: v.seconds,
+                                nanos: packet.ftime as i32
+                        }),
+                        None => Some(prost_types::Duration {
+                                seconds: 0i64,
+                                nanos: packet.ftime as i32
+                        })
+                    }
+                },
+                false => None
             },
+            time_since_gps_epoch: gps_cnt2epoch,
             crc_status: match packet.status {
                 hal::CRC::CRCOk => gw::CrcStatus::CrcOk,
                 hal::CRC::BadCRC => gw::CrcStatus::BadCrc,


### PR DESCRIPTION
This pull-request add Fine Timestamp functionality  to  consentrator-sx1302 backend.  Details and idea of this pull-request are described in  issue #65 .

## Changes

&nbsp;
`chirpstack-concentratord-sx1302/src/handler/uplink.rs`
* Added new fts (Fine TimeStamp)  filed to  Frame received, uplink_id -info message.

&nbsp;
`chirpstack-concentratord-sx1302/src/wrapper/mod.rs`
*  Added  fine_time_since_gps_epoch information into rx_info structure in uplink_to_proto() function

&nbsp;
Fine Timestamp will exist in uplink message of the consentratord if:
* Consertratord is connect to GPS and 
* PPS signal of the GPS device is connected to SX1302 hardware
*  consertrator.toml configuration file has follewing setup : 
`model_flags=["USB","GNSS"]`
 `[gateway.fine_timestamp]` 
`enable=true` 
 `mode="ALL_SF"`


Fine_time_since_gps_epoch structure has a gps time in second field if GPS device support ubx protocol. Otherwise fine_time_since_gps_epoc.seconds is set to 0 (GPS device support PPS signaling and only NMEA messages)

In this example below GPS device not support ubx messages. Only nanos field has a PPS synchronized nano seconds (to be used for TDoA calculations).
```
fine_time_since_gps_epoch: Some(Duration { seconds: 0, nanos: 110119743 }
```

Pull-request includes also fine tuning to " GPS time reference is not valid, age" warning message. If GPS devise supports only NMEA (not ubx protocol) the warning message will be shown every 10 minutes on log if  ` time_fallback_enabled=true`  flag is set in consentratord.toml file. 

```
2023-06-12T15:33:08.797Z WARN  [chirpstack_concentratord_sx1302::handler::gps] Time fallback enabled. GPS time reference is not valid, age: 1686583988.797543062s
```


" Time fallback enabled. GPS time reference is not valid, age" warning message changes can be found in the following files:
*  chirpstack-concentratord-sx1302/src/cmd/root.rs
*  chirpstack-concentratord-sx1302/src/handler/gps.rs



## Consertatord log
Log shows `fts` as follows.

```
2023-06-12T15:18:37.653Z INFO  [libconcentratord::events] Publishing stats event, rx_received: 0, rx_received_ok: 0, tx_received: 0, tx_emitted: 0
2023-06-12T15:18:49.520Z INFO  [chirpstack_concentratord_sx1302::handler::uplink] Frame received, uplink_id: 322597547, count_us: 2743161674, freq: 867700000, bw: 125000, mod: LoRa, dr: SF7, fts: 448177198 ns
2023-06-12T15:19:07.654Z INFO  [libconcentratord::events] Publishing stats event, rx_received: 1, rx_received_ok: 1, tx_received: 0, tx_emitted: 0
2023-06-12T15:19:19.554Z INFO  [chirpstack_concentratord_sx1302::handler::uplink] Frame received, uplink_id: 2725878167, count_us: 2773199919, freq: 868100000, bw: 125000, mod: LoRa, dr: SF7, fts: 486425155 ns
2023-06-12T15:19:37.655Z INFO  [libconcentratord::events] Publishing stats event, rx_received: 1, rx_received_ok: 1, tx_received: 0, tx_emitted: 0
```

## Consertatord Up event

```
Topic: up
phy_payload: [64, 97, 158, 199, 1, 128, 10, 150, 3, 70, 233, 85, 33, 42, 215, 134, 37, 33, 95, 30, 124, 29, 171]
phy_payload: UplinkRxInfo { gateway_id: "0016c001ff1f1107", uplink_id: 1540664642, time: Some(Timestamp { seconds: 1686583691, nanos: 279423171 }), time_since_gps_epoch: None, fine_time_since_gps_epoch: Some(Duration { seconds: 0, nanos: 213832907 }), rssi: -98, snr: 12.0, channel: 4, rf_chain: 0, board: 0, antenna: 0, location: None, context: [196, 253, 48, 46], metadata: {}, crc_status: CrcOk }
Topic: up
phy_payload: [64, 80, 249, 160, 0, 128, 63, 32, 2, 119, 5, 64, 180, 223, 179, 179, 51, 182, 127, 219, 10, 203, 162, 132, 79, 172, 72, 204, 168, 94, 77, 63, 71, 249, 12, 214, 9]
phy_payload: UplinkRxInfo { gateway_id: "0016c001ff1f1107", uplink_id: 2066340510, time: Some(Timestamp { seconds: 1686583701, nanos: 199794942 }), time_since_gps_epoch: None, fine_time_since_gps_epoch: Some(Duration { seconds: 0, nanos: 110119743 }), rssi: -81, snr: 11.75, channel: 3, rf_chain: 0, board: 0, antenna: 0, location: None, context: [197, 148, 129, 140], metadata: {}, crc_status: CrcOk }
```



 