### PR TITLE
Build AMD64 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build:
 	cross build --target aarch64-unknown-linux-musl --release
 	cross build --target armv5te-unknown-linux-musleabi --release
 	cross build --target armv7-unknown-linux-musleabihf --release
+	cross build --target x86_64-unknown-linux-musl --release
 
 # Update the version.
 version:
@@ -36,7 +37,10 @@ devshell:
 # Build distributable binaries.
 dist: build package
 
-package: package-targz-armv7hf package-targz-arm64 \
+package: \
+	package-targz-armv7hf \
+	package-targz-arm64	\
+	package-targz-amd64 \
 	package-kerlink-ifemtocell \
 	package-multitech-conduit \
 	package-multitech-conduit-ap
@@ -69,3 +73,10 @@ package-targz-arm64:
 	tar -czvf dist/chirpstack-concentratord-sx1301_$(PKG_VERSION)_arm64.tar.gz -C target/aarch64-unknown-linux-musl/release chirpstack-concentratord-sx1301
 	tar -czvf dist/chirpstack-concentratord-sx1302_$(PKG_VERSION)_arm64.tar.gz -C target/aarch64-unknown-linux-musl/release chirpstack-concentratord-sx1302
 	tar -czvf dist/chirpstack-concentratord-2g4_$(PKG_VERSION)_arm64.tar.gz -C target/aarch64-unknown-linux-musl/release chirpstack-concentratord-2g4
+
+package-targz-amd64:
+	$(eval PKG_VERSION := $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version'))
+	mkdir -p dist
+	tar -czvf dist/chirpstack-concentratord-sx1301_$(PKG_VERSION)_amd64.tar.gz -C target/x86_64-unknown-linux-musl/release chirpstack-concentratord-sx1301
+	tar -czvf dist/chirpstack-concentratord-sx1302_$(PKG_VERSION)_amd64.tar.gz -C target/x86_64-unknown-linux-musl/release chirpstack-concentratord-sx1302
+	tar -czvf dist/chirpstack-concentratord-2g4_$(PKG_VERSION)_amd64.tar.gz -C target/x86_64-unknown-linux-musl/release chirpstack-concentratord-2g4


### PR DESCRIPTION
Build and package concentratord binary for AMD64 (x86_64) arch. 
Useful when using SUB concentrators on a PC or an x86-based SBC.