### PR TITLE
Add seeed_wm1302_usb*

### DIFF
--- a/chirpstack-concentratord-sx1302/src/config/vendor/seeed/wm1302.rs
+++ b/chirpstack-concentratord-sx1302/src/config/vendor/seeed/wm1302.rs
@@ -166,6 +166,7 @@ pub fn new(conf: &config::Configuration) -> Result<Configuration> {
         _ => return Err(anyhow!("Region not supported: {}", region)),
     };
 
+    let usb = conf.gateway.model_flags.contains(&"USB".to_string());
     let enforce_duty_cycle = conf.gateway.model_flags.contains(&"ENFORCE_DC".to_string());
 
     Ok(Configuration {
@@ -210,12 +211,22 @@ pub fn new(conf: &config::Configuration) -> Result<Configuration> {
                 tx_gain_table: vec![],
             },
         ],
-        com_type: ComType::Spi,
-        com_path: conf
-            .gateway
-            .com_dev_path
-            .clone()
-            .unwrap_or("/dev/spidev0.0".to_string()),
+        com_type: match usb {
+            true => ComType::Usb,
+            false => ComType::Spi,
+        },
+        com_path: match usb {
+            true => conf
+                .gateway
+                .com_dev_path
+                .clone()
+                .unwrap_or("/dev/ttyACM0".to_string()),
+            false => conf
+                .gateway
+                .com_dev_path
+                .clone()
+                .unwrap_or("/dev/spidev0.0".to_string()),
+        },
         i2c_path: Some(
             conf.gateway
                 .i2c_dev_path


### PR DESCRIPTION
Add support for Seed Studio WM1302-USB-* cards, which use the standard STM32 MCU for the USB connection.