### PR TITLE
provide option to override gateway_id instead of using default embedded sx1302 eui

### DIFF
--- a/chirpstack-concentratord-sx1302/config/concentratord.toml
+++ b/chirpstack-concentratord-sx1302/config/concentratord.toml
@@ -56,3 +56,7 @@ model=""
 
 # Gateway vendor / model flags.
 model_flags=[]
+
+# Override Gateway ID.
+# Comment out to use the embedded SX1302 EUI.
+gateway_id=""

--- a/chirpstack-concentratord-sx1302/src/cmd/configfile.rs
+++ b/chirpstack-concentratord-sx1302/src/cmd/configfile.rs
@@ -74,6 +74,9 @@ pub fn run(config: &config::Configuration) {
   #     USB  - Use USB for concentrator communication (default is SPI)
   model_flags=[{{#each gateway.model_flags}}"{{ this }},{{/each}}]
 
+  # Gateway ID.
+  gateway_id="{{ gateway.gateway_id }}"
+
   # Time fallback.
   #
   # In case the gateway does not have a GNSS module or is unable to aquire a

--- a/chirpstack-concentratord-sx1302/src/cmd/root.rs
+++ b/chirpstack-concentratord-sx1302/src/cmd/root.rs
@@ -45,12 +45,25 @@ pub fn run(
     );
 
     // get concentrator eui
-    let gateway_id = concentrator::get_eui().unwrap();
+    let mut gateway_id = concentrator::get_eui().unwrap();
 
     info!(
         "Gateway ID retrieved, gateway_id: {:x?}",
         hex::encode(gateway_id)
     );
+
+    // check if gateway_id is specified in config file,
+    // in which case it will override the embedded sx1302 eui
+    let sum: u8 = config.gateway.gateway_id_bytes.iter().sum();
+    if sum != 0 {
+        let id = config.gateway.gateway_id_bytes.as_slice();
+        gateway_id = id[0..8].try_into().unwrap();
+
+        info!(
+            "Gateway ID overriden by config, gateway_id: {:x?}",
+            hex::encode(gateway_id)
+        );
+    }
 
     // setup jit queue
     let queue: jitqueue::Queue<wrapper::TxPacket> =

--- a/packaging/vendor/multitech/conduit-ap3/files/chirpstack-concentratord.init
+++ b/packaging/vendor/multitech/conduit-ap3/files/chirpstack-concentratord.init
@@ -10,6 +10,9 @@ DAEMON_PID=/var/run/$NAME.pid
 read_lora_hw_info() {
 	lora_id=$(mts-io-sysfs show lora/product-id 2> /dev/null)
 	lora_hw=$(mts-io-sysfs show lora/hw-version 2> /dev/null)
+	lora_eui=$(mts-io-sysfs show lora/eui 2> /dev/null)
+        # remove all colons
+        lora_eui_raw=${lora_eui//:/}
 }
 
 hardware_found() {
@@ -43,6 +46,7 @@ copy_config() {
 
 	sed -i "s/region=.*/region=\"${region}\"/" $DAEMON_CONF_DIR/concentratord.toml
 	sed -i "s/model=.*/model=\"multitech_${model}\"/" $DAEMON_CONF_DIR/concentratord.toml
+	sed -i "s/gateway_id=.*/gateway_id=\"${lora_eui_raw}\"/" $DAEMON_CONF_DIR/concentratord.toml
 }
 
 do_start() {

--- a/packaging/vendor/multitech/conduit-ap3/files/concentratord.toml
+++ b/packaging/vendor/multitech/conduit-ap3/files/concentratord.toml
@@ -48,7 +48,8 @@ model=""
 # Gateway vendor / model flags.
 model_flags=[]
 
-# Gateway ID.
+# Override Gateway ID.
+# Comment out to use the embedded SX1302 EUI.
 gateway_id=""
 
 # Time fallback.


### PR DESCRIPTION
Default behavior will use the overriden gateway_id option in config file (value will be replaced by the MultiTech LoRa EUI in init script start).

Commenting out the gateway_id option in config file will force concentratord to use the embedded sx1302 eui.